### PR TITLE
fix: - gmi service failing due to timelag validation

### DIFF
--- a/files/dataset.json
+++ b/files/dataset.json
@@ -43,7 +43,7 @@
             "distributionReleaseDate": null,
             "startDate": "2007-01-04",
             "endDate": null,
-            "timeLag": null
+            "timeLag": "Not applicable"
         }
     },
     "accessibility": {


### PR DESCRIPTION
Added in one of the accepted values for timeLag:

![image](https://github.com/user-attachments/assets/d6b6d8a3-78dd-4048-ad38-02406d391c8e)
